### PR TITLE
Match terms case insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,10 @@ By default we show a tooltip when a word matches case insensitively: when the te
 You can configure this to be case sensitive for all terms, so "Hello" only matches for "Hello":
 
 ```
-config.settings.glossary = {
-...config.settings.glossary,
-    case_sensitive: true,
-}
+config.settings.glossary.caseSensitive = true;
 ```
 
-Regardless of this setting, when you have a fully uppercase term, for example `REST` (REpresentational State Transfer), always only the exact word `REST` gets a tooltip, not `rest` or `Rest`.
+Regardless of this setting, when you have a fully uppercase term, for example `REST` (Representational State Transfer), always only the exact word `REST` gets a tooltip, not `rest` or `Rest`.
 
 Install Plone Add-On [collective.glossary](https://github.com/collective/collective.glossary) in your backend.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Determine where to apply tooltips in your project by match configuration:
         return config;
     }
 
+By default we show a tooltip when a word matches case insensitively: when the term is "Hello" or "hello", a tooltip is shown for "Hello", "hello", "HELLO", "hElLo", etcetera.
+
+You can configure this to be case sensitive for all terms, so "Hello" only matches for "Hello":
+
+```
+config.settings.glossary = {
+...config.settings.glossary,
+    case_sensitive: true,
+}
+```
+
+Regardless of this setting, when you have a fully uppercase term, for example `REST` (REpresentational State Transfer), always only the exact word `REST` gets a tooltip, not `rest` or `Rest`.
 
 Install Plone Add-On [collective.glossary](https://github.com/collective/collective.glossary) in your backend.
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,12 @@ export default (config) => {
   config.settings.slate.leafs = {
     text: ({ children }) => <TextWithGlossaryTooltips text={children} />,
   };
+  config.settings = {
+    ...config.settings,
+    glossary: {
+      case_sensitive: false,
+    }
+  }
   config.views = {
     ...config.views,
     contentTypesViews: {

--- a/src/index.js
+++ b/src/index.js
@@ -4,15 +4,12 @@ import { glossarytermsReducer, glossarytooltiptermsReducer } from './reducers';
 import { TextWithGlossaryTooltips } from './utils';
 
 export default (config) => {
+  config.settings.glossary = {
+    caseSensitive: false,
+  };
   config.settings.slate.leafs = {
     text: ({ children }) => <TextWithGlossaryTooltips text={children} />,
   };
-  config.settings = {
-    ...config.settings,
-    glossary: {
-      case_sensitive: false,
-    }
-  }
   config.views = {
     ...config.views,
     contentTypesViews: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,16 +55,14 @@ export const TextWithGlossaryTooltips = ({ text }) => {
     glossaryterms.forEach((term) => {
       result = result.map((chunk) => {
         if (chunk.type === 'text') {
-          var myre;
           let new_chunk = [];
-          // regex word boundary does ignore umlauts and other non ascii
-          if (['ä', 'ö', 'ü', 'Ä', 'Ö', 'Ü'].includes(term.term[0])) {
-            // let myre = `(?<!\w)${term.term}(?!\w)`;
-            myre = `(?<=[ ,\.])(${term.term})(?=[ ,\.])`;
-          } else {
-            myre = `\\b(${term.term})\\b`;
-          }
-          let regExpTerm = new RegExp(myre, "gi");
+          // regex word boundary \b ignores umlauts and other non ascii characters.
+          // So we pass the 'v' flag for upgraded unicode support:
+          // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets
+          // And we use '\p{L}' to match any unicode from the 'letter' category.
+          // See https://javascript.info/regexp-unicode
+          let myre = `(?<!\\p{L})(${term.term})(?!\\p{L})`;
+          let regExpTerm = RegExp(myre, "giv");
           let chunk_val = chunk.val;
           let index = 0;
           while (true) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,13 +56,20 @@ export const TextWithGlossaryTooltips = ({ text }) => {
       result = result.map((chunk) => {
         if (chunk.type === 'text') {
           let new_chunk = [];
+          let regExpTerm;
           // regex word boundary \b ignores umlauts and other non ascii characters.
           // So we pass the 'v' flag for upgraded unicode support:
           // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets
           // And we use '\p{L}' to match any unicode from the 'letter' category.
           // See https://javascript.info/regexp-unicode
           let myre = `(?<!\\p{L})(${term.term})(?!\\p{L})`;
-          let regExpTerm = RegExp(myre, "giv");
+          if (term.term === term.term.toUpperCase()) {
+            // Search case sensitively: if term is 'REST', we don't want to highlight 'rest'.
+            regExpTerm = RegExp(myre, "gv");
+          } else {
+            // Search case insensitively.
+            regExpTerm = RegExp(myre, "giv");
+          }
           let chunk_val = chunk.val;
           let index = 0;
           while (true) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import config from '@plone/volto/registry';
 import { useSelector } from 'react-redux';
 import { flatten } from 'lodash';
 import { Popup } from 'semantic-ui-react';
 import { useLocation } from 'react-router-dom';
+
 
 /**
  * import from @plone/volto-slate Leaf when ready there
@@ -33,6 +35,7 @@ const applyLineBreakSupport = (children) => {
 };
 
 export const TextWithGlossaryTooltips = ({ text }) => {
+  const case_sensitive = config.settings.glossary.case_sensitive;
   const glossaryterms = useSelector(
     (state) => state.glossarytooltipterms?.result?.items,
   );
@@ -63,7 +66,7 @@ export const TextWithGlossaryTooltips = ({ text }) => {
           // And we use '\p{L}' to match any unicode from the 'letter' category.
           // See https://javascript.info/regexp-unicode
           let myre = `(?<!\\p{L})(${term.term})(?!\\p{L})`;
-          if (term.term === term.term.toUpperCase()) {
+          if (case_sensitive || term.term === term.term.toUpperCase()) {
             // Search case sensitively: if term is 'REST', we don't want to highlight 'rest'.
             regExpTerm = RegExp(myre, "gv");
           } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ const applyLineBreakSupport = (children) => {
 };
 
 export const TextWithGlossaryTooltips = ({ text }) => {
-  const case_sensitive = config.settings.glossary.case_sensitive;
+  const caseSensitive = config.settings.glossary.caseSensitive;
   const glossaryterms = useSelector(
     (state) => state.glossarytooltipterms?.result?.items,
   );
@@ -66,7 +66,7 @@ export const TextWithGlossaryTooltips = ({ text }) => {
           // And we use '\p{L}' to match any unicode from the 'letter' category.
           // See https://javascript.info/regexp-unicode
           let myre = `(?<!\\p{L})(${term.term})(?!\\p{L})`;
-          if (case_sensitive || term.term === term.term.toUpperCase()) {
+          if (caseSensitive || term.term === term.term.toUpperCase()) {
             // Search case sensitively: if term is 'REST', we don't want to highlight 'rest'.
             regExpTerm = RegExp(myre, "gv");
           } else {


### PR DESCRIPTION
And fix the regular expression to also work for umlauts at the beginning or end of a word.  This should work for other non-ascii characters as well.

I have this glossary for testing:

![Screenshot 2024-09-10 at 14 55 36](https://github.com/user-attachments/assets/8eda32b0-921c-41b3-bbf6-bb0ebe615148)

Initially with the main branch a test page looks like this:

![Screenshot 2024-09-10 at 14 34 52](https://github.com/user-attachments/assets/de7eba09-babd-44c6-a424-f48e75042b39)

Problem (for me) is that this only shows glossary items when the case matches.  This is fixed with the first commit:

![Screenshot 2024-09-10 at 14 34 59](https://github.com/user-attachments/assets/3b464373-5bd3-4cc5-af89-8847b4cee717)

Then I started looking at the support for accented characters, and found that it did not work if such a character was at the start or end of a term.  So I did another commit:

![Screenshot 2024-09-10 at 14 35 09](https://github.com/user-attachments/assets/6248adb9-6a8c-4ac3-87ce-e87c2abefbbc)




