### PR TITLE
When viewing a Glossary, show an alphabet at the top.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This provides the content type `glossary`.
 
 Determine where to apply tooltips in your project by match configuration:
 
-```javascript
+```js
     import { Tooltips } from '@rohberg/volto-slate-glossary/components';
 
     export default function applyConfig(config) {
@@ -38,7 +38,7 @@ By default we show a tooltip when a word matches case insensitively: when the te
 
 You can configure this to be case sensitive for all terms, so "Hello" only matches for "Hello":
 
-```
+```js
 config.settings.glossary.caseSensitive = true;
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @rohberg/volto-slate-glossary
 
-Volto Add-On `@rohberg/volto-slate-glossary` adds tooltips for glossary terms of [collective.glossary](https://github.com/collective/collective.glossary)
+Volto add-on `@rohberg/volto-slate-glossary` adds tooltips for glossary terms of [collective.glossary](https://github.com/collective/collective.glossary)
 
 [![npm](https://img.shields.io/npm/v/@rohberg/volto-slate-glossary)](https://www.npmjs.com/package/@rohberg/volto-slate-glossary)
 [![Unit tests](https://github.com/rohberg/volto-slate-glossary/actions/workflows/unit.yml/badge.svg)](https://github.com/rohberg/volto-slate-glossary/actions/workflows/unit.yml)
@@ -9,8 +9,12 @@ Volto Add-On `@rohberg/volto-slate-glossary` adds tooltips for glossary terms of
 
 ![Tooltips @rohberg/volto-slate-glossary](https://github.com/rohberg/volto-slate-glossary/raw/main/docs/volto-slate-glossary-tooltips.png)
 
+Install Plone add-on [collective.glossary](https://github.com/collective/collective.glossary) in your backend.
+This provides the content type `glossary`.
+
 Determine where to apply tooltips in your project by match configuration:
 
+```javascript
     import { Tooltips } from '@rohberg/volto-slate-glossary/components';
 
     export default function applyConfig(config) {
@@ -28,6 +32,7 @@ Determine where to apply tooltips in your project by match configuration:
 
         return config;
     }
+```
 
 By default we show a tooltip when a word matches case insensitively: when the term is "Hello" or "hello", a tooltip is shown for "Hello", "hello", "HELLO", "hElLo", etcetera.
 
@@ -39,19 +44,14 @@ config.settings.glossary.caseSensitive = true;
 
 Regardless of this setting, when you have a fully uppercase term, for example `REST` (Representational State Transfer), always only the exact word `REST` gets a tooltip, not `rest` or `Rest`.
 
-By default we show a tooltip for all matches on a page.
-You can configure this to only show a tooltip for the first match:
+By default we show tooltips for all occurrences of a term.
 
-```
+Since version 2.0.0 you can configure to only show tooltips for the first occurence on a page.
+
+```js
 config.settings.glossary.matchOnlyFirstOccurence = true;
 ```
-
-Install Plone add-on [collective.glossary](https://github.com/collective/collective.glossary) in your backend.
-This provides the content type `glossary`.
 
 
 User can opt-out by setting glossarytooltips to false.
 Add a boolean member field *glossarytooltips* for it.
-
-
-This add-on requires Volto with Slate editor. Be sure to upgrade to Volto >= 16.0.0-alpha.15.

--- a/backend/CONTRIBUTORS.md
+++ b/backend/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 # Contributors
 
-- Plone Foundation [collective@plone.org]
+- Katja Süss [@ksuess]
+- Maurits van Rees [@mauritsvanrees]

--- a/packages/policy/src/index.js
+++ b/packages/policy/src/index.js
@@ -4,6 +4,7 @@ const applyConfig = (config) => {
   // glossary tooltips
   config.settings.glossary.caseSensitive = false;
   config.settings.glossary.matchOnlyFirstOccurence = false;
+  config.settings.glossary.showAlphabetNavigation = true;
 
   // Tooltips everywhere
   config.settings.appExtras = [

--- a/packages/volto-slate-glossary/news/11.feature
+++ b/packages/volto-slate-glossary/news/11.feature
@@ -1,1 +1,1 @@
-Show an alphabet navigation on glossary. Clicking a letter scrolls the entries for this letter into view. @mauritsvanrees
+Show an alphabet navigation on glossary. Clicking a letter scrolls the entries for this letter into view. @mauritsvanrees, @ksuess

--- a/packages/volto-slate-glossary/news/11.feature
+++ b/packages/volto-slate-glossary/news/11.feature
@@ -1,0 +1,3 @@
+When viewing a Glossary, show an alphabet at the top.
+Clicking a letter scrolls the entries for that letter into view.
+@mauritsvanrees

--- a/packages/volto-slate-glossary/news/11.feature
+++ b/packages/volto-slate-glossary/news/11.feature
@@ -1,3 +1,1 @@
-When viewing a Glossary, show an alphabet at the top.
-Clicking a letter scrolls the entries for that letter into view.
-@mauritsvanrees
+Show an alphabet navigation on glossary. Clicking a letter scrolls the entries for this letter into view. @mauritsvanrees

--- a/packages/volto-slate-glossary/src/components/GlossaryView.jsx
+++ b/packages/volto-slate-glossary/src/components/GlossaryView.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Container } from 'semantic-ui-react';
 import { useSelector, useDispatch } from 'react-redux';
 import { getGlossaryTerms } from '../actions';
 
+const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const GlossaryView = ({ content }) => {
   const dispatch = useDispatch();
   const pathname = useSelector((state) => state.router.location.pathname);
@@ -17,18 +17,36 @@ const GlossaryView = ({ content }) => {
   );
 
   return (
-    <Container className="view-wrapper">
-      <article id="content">
-        <header>
-          <h1 className="documentFirstHeading">{content.title}</h1>
-          {content.description && (
-            <p className="documentDescription">{content.description}</p>
-          )}
-        </header>
-        <section id="content-core" className="glossary">
+    <div id="page-document" className="q-container">
+      <div className="blocks-group-wrapper transparent">
+        <h1 className="documentFirstHeading">{content.title}</h1>
+        {content.description && (
+          <p className="documentDescription">{content.description}</p>
+        )}
+
+        <div className="glossaryAlphabet">
+          {alphabet.split('').map((letter) => (
+            <Link
+              key={letter}
+              to={'#' + letter}
+              className="alphabetLetter"
+              onClick={() => {
+                document
+                  .getElementById(letter)
+                  ?.scrollIntoView({ behavior: 'smooth' });
+              }}
+            >
+              <span>{letter}</span>
+            </Link>
+          ))}
+        </div>
+
+        <section className="glossary">
           {Object.keys(glossaryentries || {})?.map((letter) => (
             <div key={letter}>
-              <h2 className="letter">{letter}</h2>
+              <a id={letter} anchor={letter} href={false}>
+                <h2 className="letter">{letter}</h2>
+              </a>
               {glossaryentries[letter].map((item) => (
                 <article className="term" key={item['@id']}>
                   <h3>
@@ -50,8 +68,8 @@ const GlossaryView = ({ content }) => {
             </div>
           ))}
         </section>
-      </article>
-    </Container>
+      </div>
+    </div>
   );
 };
 

--- a/packages/volto-slate-glossary/src/components/GlossaryView.jsx
+++ b/packages/volto-slate-glossary/src/components/GlossaryView.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Container } from 'semantic-ui-react';
 import { useSelector, useDispatch } from 'react-redux';
+import cx from 'classnames';
 import { getGlossaryTerms } from '../actions';
+import config from '@plone/volto/registry';
 
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const showAlphabetNavigation =
+  config.settings?.glossary?.showAlphabetNavigation || true;
+
 const GlossaryView = ({ content }) => {
   const dispatch = useDispatch();
   const pathname = useSelector((state) => state.router.location.pathname);
@@ -12,41 +18,49 @@ const GlossaryView = ({ content }) => {
     dispatch(getGlossaryTerms());
   }, [dispatch, pathname]);
 
-  let glossaryentries = useSelector(
+  const glossaryentries = useSelector(
     (state) => state.glossaryterms.result.items,
   );
+  const lettersWithTerm = Object.keys(glossaryentries || {});
 
   return (
-    <div id="page-document" className="q-container">
-      <div className="blocks-group-wrapper transparent">
-        <h1 className="documentFirstHeading">{content.title}</h1>
-        {content.description && (
-          <p className="documentDescription">{content.description}</p>
-        )}
+    <Container className="view-wrapper glossary-view">
+      <article id="content">
+        <header>
+          <h1 className="documentFirstHeading">{content.title}</h1>
+          {content.description && (
+            <p className="documentDescription">{content.description}</p>
+          )}
+        </header>
 
-        <div className="glossaryAlphabet">
-          {alphabet.split('').map((letter) => (
-            <Link
-              key={letter}
-              to={'#' + letter}
-              className="alphabetLetter"
-              onClick={() => {
-                document
-                  .getElementById(letter)
-                  ?.scrollIntoView({ behavior: 'smooth' });
-              }}
-            >
-              <span>{letter}</span>
-            </Link>
-          ))}
-        </div>
+        {showAlphabetNavigation ? (
+          <div className="glossaryAlphabet">
+            {alphabet.split('').map((letter) => (
+              <Link
+                key={letter}
+                to={'#' + letter}
+                className={cx(
+                  'alphabetLetter',
+                  `${!lettersWithTerm.includes(letter) ? 'unmatched' : 'matched'}`,
+                )}
+                onClick={() => {
+                  document
+                    .getElementById(letter)
+                    ?.scrollIntoView({ behavior: 'smooth' });
+                }}
+              >
+                <span>{letter}</span>
+              </Link>
+            ))}
+          </div>
+        ) : null}
 
-        <section className="glossary">
+        <section id="content-core" className="glossary">
           {Object.keys(glossaryentries || {})?.map((letter) => (
             <div key={letter}>
-              <a id={letter} anchor={letter} href={false}>
-                <h2 className="letter">{letter}</h2>
-              </a>
+              <h2 id={letter} className="letter">
+                {letter}
+              </h2>
               {glossaryentries[letter].map((item) => (
                 <article className="term" key={item['@id']}>
                   <h3>
@@ -68,8 +82,8 @@ const GlossaryView = ({ content }) => {
             </div>
           ))}
         </section>
-      </div>
-    </div>
+      </article>
+    </Container>
   );
 };
 

--- a/packages/volto-slate-glossary/src/components/glossarytooltips.less
+++ b/packages/volto-slate-glossary/src/components/glossarytooltips.less
@@ -21,6 +21,15 @@
   background: #963c38;
   color: white;
 }
+.glossary-view .glossaryAlphabet {
+  padding: 1em 0;
+  .alphabetLetter {
+    padding-right: 0.3em;
+    &.unmatched {
+      filter: opacity(0.5);
+    }
+  }
+}
 .term h3 {
   span {
     font-size: 80%;

--- a/packages/volto-slate-glossary/src/index.js
+++ b/packages/volto-slate-glossary/src/index.js
@@ -8,6 +8,7 @@ const applyConfig = (config) => {
   config.settings.glossary = {
     caseSensitive: false,
     matchOnlyFirstOccurence: false,
+    showAlphabetNavigation: true,
   };
 
   config.settings.slate.leafs = {


### PR DESCRIPTION
Clicking a letter scrolls the entries for that letter into view.

This is a customisation from the same client project where we are looking at https://github.com/rohberg/volto-slate-glossary/pull/10, so I base this PR on that branch, for ease of my own testing.

Note that `collective.glossary` has a registry setting with a "Maximum before showing A-Z toolbar", which works in Classic UI.  We did not implement checking this registry setting here because for this client we have hundreds of glossary terms and always want to show the A-Z bar.

An integrator would need to do some styling.
Screenshot with only this add-on:

![Screenshot 2024-10-24 at 21 44 58](https://github.com/user-attachments/assets/cd5f2f36-733e-470f-9796-29c237fa9ae9)

Screenshot in the client project:

![Screenshot 2024-10-24 at 21 45 20](https://github.com/user-attachments/assets/917424e9-3f0a-44e3-9207-a39d7732e9a5)

Note that this PR changes a few tags/ids/classes and I don't know why, I just copy some code here.  The client project uses volto-light-theme, that may be why.
