### PR TITLE
Fix React hooks error: render TextWithGlossaryTooltips as JSX component

### DIFF
--- a/jest-addon.config.js
+++ b/jest-addon.config.js
@@ -1,12 +1,8 @@
 module.exports = {
-  roots: [
-    '<rootDir>/../../../packages',
-    '<rootDir>/../../../addons',
-  ],
+  roots: ['<rootDir>/../../../packages'],
   testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
   collectCoverageFrom: [
     '<rootDir>/../../../packages/**/src/**/*.{js,jsx,ts,tsx}',
-    '<rootDir>/../../../addons/**/src/**/*.{js,jsx,ts,tsx}',
     '!**/*.d.ts',
   ],
   transformIgnorePatterns: ['node_modules/(?!(volto-slate|@plone/volto)/)'],

--- a/jest-addon.config.js
+++ b/jest-addon.config.js
@@ -1,9 +1,13 @@
 module.exports = {
-  roots: ['../../../packages'],
-  testMatch: ['<rootDir>/../../../../**/?(*.)+(spec|test).[jt]s?(x)'],
+  roots: [
+    '<rootDir>/../../../packages',
+    '<rootDir>/../../../addons',
+  ],
+  testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
   collectCoverageFrom: [
-    'src/addons/**/src/**/*.{js,jsx,ts,tsx}',
-    '!src/**/*.d.ts',
+    '<rootDir>/../../../packages/**/src/**/*.{js,jsx,ts,tsx}',
+    '<rootDir>/../../../addons/**/src/**/*.{js,jsx,ts,tsx}',
+    '!**/*.d.ts',
   ],
   transformIgnorePatterns: ['node_modules/(?!(volto-slate|@plone/volto)/)'],
   coverageThreshold: {

--- a/packages/policy/src/components/AccordionBlockViewWithTooltips.jsx
+++ b/packages/policy/src/components/AccordionBlockViewWithTooltips.jsx
@@ -188,7 +188,7 @@ const View = (props) => {
                     }
                   />
                   <span>
-                    {TextWithGlossaryTooltips({ text: panel?.title })}
+                    <TextWithGlossaryTooltips text={panel?.title} />
                   </span>
                 </Accordion.Title>
                 <AnimateHeight

--- a/packages/policy/src/components/DescriptionBlockViewWithTooltips.jsx
+++ b/packages/policy/src/components/DescriptionBlockViewWithTooltips.jsx
@@ -2,7 +2,7 @@ import { TextWithGlossaryTooltips } from '@rohberg/volto-slate-glossary/utils';
 
 const DescriptionBlockView = ({ properties, metadata, id }) => {
   let description = (metadata || properties)['description'] || '';
-  description = TextWithGlossaryTooltips({ text: description });
+  description = <TextWithGlossaryTooltips text={description} />;
 
   return <p className="documentDescription">{description}</p>;
 };

--- a/packages/policy/src/components/TeaserViewWithTooltips.jsx
+++ b/packages/policy/src/components/TeaserViewWithTooltips.jsx
@@ -9,10 +9,8 @@ const TeaserView = (props) => {
         ...props,
         data: {
           ...props.data,
-          description: TextWithGlossaryTooltips({
-            text: props.data.description,
-          }),
-          title: TextWithGlossaryTooltips({ text: props.data.title }),
+          description: <TextWithGlossaryTooltips text={props.data.description} />,
+          title: <TextWithGlossaryTooltips text={props.data.title} />,
         },
       }}
     />

--- a/packages/policy/src/components/TeaserViewWithTooltips.jsx
+++ b/packages/policy/src/components/TeaserViewWithTooltips.jsx
@@ -9,7 +9,9 @@ const TeaserView = (props) => {
         ...props,
         data: {
           ...props.data,
-          description: <TextWithGlossaryTooltips text={props.data.description} />,
+          description: (
+            <TextWithGlossaryTooltips text={props.data.description} />
+          ),
           title: <TextWithGlossaryTooltips text={props.data.title} />,
         },
       }}

--- a/packages/policy/src/components/TitleBlockViewWithTooltips.jsx
+++ b/packages/policy/src/components/TitleBlockViewWithTooltips.jsx
@@ -2,7 +2,7 @@ import { TextWithGlossaryTooltips } from '@rohberg/volto-slate-glossary/utils';
 
 const BlockView = ({ properties, metadata, id }) => {
   let title = (metadata || properties)['title'] || '';
-  title = TextWithGlossaryTooltips({ text: title });
+  title = <TextWithGlossaryTooltips text={title} />;
   return <h1 className="documentFirstHeading">{title}</h1>;
 };
 

--- a/packages/volto-slate-glossary/src/components/Tooltips.empty-definition.test.jsx
+++ b/packages/volto-slate-glossary/src/components/Tooltips.empty-definition.test.jsx
@@ -1,0 +1,51 @@
+import config from '@plone/volto/registry';
+import { enhanceTextWithTooltips } from './Tooltips';
+
+const TooltipPopup = ({ term, definition }) => (
+  <span data-testid="tooltip-popup" data-definition={definition}>
+    {term}
+  </span>
+);
+
+beforeAll(() => {
+  config.settings.glossary = {
+    caseSensitive: false,
+    matchOnlyFirstOccurence: false,
+  };
+  config.registerComponent({
+    name: 'TooltipPopup',
+    component: TooltipPopup,
+  });
+});
+
+describe('enhanceTextWithTooltips – empty definition guard', () => {
+  it('does not render a TooltipPopup when definition is undefined', () => {
+    const [nodes] = enhanceTextWithTooltips('hello term world', [
+      { term: 'term', definition: undefined },
+    ]);
+    const hasTooltip = nodes.some(
+      (n) => n && n.props && n.props['data-testid'] === 'tooltip-popup',
+    );
+    expect(hasTooltip).toBe(false);
+  });
+
+  it('does not render a TooltipPopup when definition is an empty array', () => {
+    const [nodes] = enhanceTextWithTooltips('hello term world', [
+      { term: 'term', definition: [] },
+    ]);
+    const hasTooltip = nodes.some(
+      (n) => n && n.props && n.props['data-testid'] === 'tooltip-popup',
+    );
+    expect(hasTooltip).toBe(false);
+  });
+
+  it('still renders a TooltipPopup when definition has content', () => {
+    const [nodes] = enhanceTextWithTooltips('hello term world', [
+      { term: 'term', definition: ['<p>a definition</p>'] },
+    ]);
+    const hasTooltip = nodes.some(
+      (n) => n && n.props && n.props['data-testid'] === 'tooltip-popup',
+    );
+    expect(hasTooltip).toBe(true);
+  });
+});

--- a/packages/volto-slate-glossary/src/components/Tooltips.jsx
+++ b/packages/volto-slate-glossary/src/components/Tooltips.jsx
@@ -223,43 +223,35 @@ const calculateTexts = (content, glossaryterms) => {
   const blocks = content?.blocks;
   const blocks_layout = content?.blocks_layout;
 
+  function processText(el) {
+    if (!el) return;
+    const key = uuidv5(el, MY_NAMESPACE);
+    if (Object.keys(result).includes(key)) return;
+    const [value, newTerms] = enhanceTextWithTooltips(
+      el,
+      remainingGlossaryterms,
+    );
+    result[key] = value;
+    remainingGlossaryterms = newTerms;
+  }
+
+  function processSlateValue(slateValue) {
+    const arrayOfStrings = flattenDeep(serializeNodes(slateValue));
+    arrayOfStrings.forEach((str) => {
+      if (str.length === 0) return;
+      processText(str);
+    });
+  }
+
   function iterateOverBlocks(blocks, blocks_layout) {
     blocks_layout?.items &&
       blocks_layout.items.forEach((blockid) => {
-        [blocks[blockid].title, blocks[blockid].description].forEach((el) => {
-          if (el) {
-            const key = uuidv5(el, MY_NAMESPACE);
-            if (Object.keys(result).includes(key)) {
-              return;
-            }
-            const [value, newTerms] = enhanceTextWithTooltips(
-              el,
-              remainingGlossaryterms,
-            );
-            result[key] = value;
-            remainingGlossaryterms = newTerms;
-          }
-        });
+        [blocks[blockid].title, blocks[blockid].description].forEach(
+          processText,
+        );
         if (blocks[blockid].value) {
           // Simple slate block
-          const arrayOfStrings = flattenDeep(
-            serializeNodes(blocks[blockid].value),
-          );
-          arrayOfStrings.forEach((str) => {
-            if (str.length === 0) {
-              return;
-            }
-            const key = uuidv5(str, MY_NAMESPACE);
-            if (Object.keys(result).includes(key)) {
-              return;
-            }
-            const [value, newTerms] = enhanceTextWithTooltips(
-              str,
-              remainingGlossaryterms,
-            );
-            result[key] = value;
-            remainingGlossaryterms = newTerms;
-          });
+          processSlateValue(blocks[blockid].value);
         } else {
           // Nested blocks
           // block type 'gridBlock' or '"accordionPanel"
@@ -281,24 +273,40 @@ const calculateTexts = (content, glossaryterms) => {
             );
           }
         }
+        // Slate content stored as 'content' property (e.g. InfoBox)
+        if (
+          blocks[blockid].content &&
+          Array.isArray(blocks[blockid].content)
+        ) {
+          processSlateValue(blocks[blockid].content);
+        }
+        // Table cell values
+        if (blocks[blockid].table?.rows) {
+          blocks[blockid].table.rows.forEach((row) => {
+            row.cells?.forEach((cell) => {
+              if (cell.value) {
+                processSlateValue(cell.value);
+              }
+            });
+          });
+        }
+        // Slider slide text
+        if (blocks[blockid].slides) {
+          blocks[blockid].slides.forEach((slide) => {
+            [slide.title, slide.description].forEach(processText);
+          });
+        }
+        // CardSection column text
+        if (blocks[blockid].columns) {
+          blocks[blockid].columns.forEach((column) => {
+            [column.title, column.description].forEach(processText);
+          });
+        }
       });
   }
   iterateOverBlocks(blocks, blocks_layout);
 
-  [content?.title, content?.description].forEach((el) => {
-    if (el) {
-      const key = uuidv5(el, MY_NAMESPACE);
-      if (Object.keys(result).includes(key)) {
-        return;
-      }
-      const [value, newTerms] = enhanceTextWithTooltips(
-        el,
-        remainingGlossaryterms,
-      );
-      result[key] = value;
-      remainingGlossaryterms = newTerms;
-    }
-  });
+  [content?.title, content?.description].forEach(processText);
 
   return result;
 };

--- a/packages/volto-slate-glossary/src/components/Tooltips.jsx
+++ b/packages/volto-slate-glossary/src/components/Tooltips.jsx
@@ -294,7 +294,7 @@ const calculateTexts = (content, glossaryterms) => {
           });
         }
         // CardSection column text
-        if (blocks[blockid].columns) {
+        if (blocks[blockid].columns && Array.isArray(blocks[blockid].columns)) {
           blocks[blockid].columns.forEach((column) => {
             [column.title, column.description].forEach(processText);
           });

--- a/packages/volto-slate-glossary/src/components/Tooltips.jsx
+++ b/packages/volto-slate-glossary/src/components/Tooltips.jsx
@@ -278,7 +278,10 @@ const calculateTexts = (content, glossaryterms) => {
           processSlateValue(blocks[blockid].content);
         }
         // Table cell values
-        if (blocks[blockid].table?.rows && Array.isArray(blocks[blockid].table.rows)) {
+        if (
+          blocks[blockid].table?.rows &&
+          Array.isArray(blocks[blockid].table.rows)
+        ) {
           blocks[blockid].table.rows.forEach((row) => {
             row.cells?.forEach((cell) => {
               if (cell.value) {

--- a/packages/volto-slate-glossary/src/components/Tooltips.jsx
+++ b/packages/volto-slate-glossary/src/components/Tooltips.jsx
@@ -274,10 +274,7 @@ const calculateTexts = (content, glossaryterms) => {
           }
         }
         // Slate content stored as 'content' property (e.g. InfoBox)
-        if (
-          blocks[blockid].content &&
-          Array.isArray(blocks[blockid].content)
-        ) {
+        if (blocks[blockid].content && Array.isArray(blocks[blockid].content)) {
           processSlateValue(blocks[blockid].content);
         }
         // Table cell values

--- a/packages/volto-slate-glossary/src/components/Tooltips.jsx
+++ b/packages/volto-slate-glossary/src/components/Tooltips.jsx
@@ -173,19 +173,20 @@ export const enhanceTextWithTooltips = (text, remainingGlossaryterms) => {
         let idx = remainingGlossaryterms.findIndex(
           (variant) => variant.term.toLowerCase() === el.val.toLowerCase(),
         );
-        let definition = remainingGlossaryterms[idx]?.definition || '';
-        switch (definition.length) {
-          case 0:
-            definition = '';
-            break;
-          case 1:
-            definition = definition[0];
-            break;
-          default:
-            let arrayOfListNodes = definition
-              .map((el) => `<li>${el}</li>`)
-              .join('');
-            definition = `<ol>${arrayOfListNodes}</ol>`;
+        let definition = remainingGlossaryterms[idx]?.definition;
+        if (
+          !definition ||
+          (Array.isArray(definition) && definition.length === 0)
+        ) {
+          return applyLineBreakSupport(el.val);
+        }
+        if (definition.length === 1) {
+          definition = definition[0];
+        } else {
+          let arrayOfListNodes = definition
+            .map((el) => `<li>${el}</li>`)
+            .join('');
+          definition = `<ol>${arrayOfListNodes}</ol>`;
         }
         const TooltipPopup = config.getComponent('TooltipPopup').component;
         return (

--- a/packages/volto-slate-glossary/src/components/Tooltips.jsx
+++ b/packages/volto-slate-glossary/src/components/Tooltips.jsx
@@ -278,7 +278,7 @@ const calculateTexts = (content, glossaryterms) => {
           processSlateValue(blocks[blockid].content);
         }
         // Table cell values
-        if (blocks[blockid].table?.rows) {
+        if (blocks[blockid].table?.rows && Array.isArray(blocks[blockid].table.rows)) {
           blocks[blockid].table.rows.forEach((row) => {
             row.cells?.forEach((cell) => {
               if (cell.value) {
@@ -288,7 +288,7 @@ const calculateTexts = (content, glossaryterms) => {
           });
         }
         // Slider slide text
-        if (blocks[blockid].slides) {
+        if (blocks[blockid].slides && Array.isArray(blocks[blockid].slides)) {
           blocks[blockid].slides.forEach((slide) => {
             [slide.title, slide.description].forEach(processText);
           });

--- a/packages/volto-slate-glossary/src/components/__snapshots__/Tooltips.test.jsx.snap
+++ b/packages/volto-slate-glossary/src/components/__snapshots__/Tooltips.test.jsx.snap
@@ -383,22 +383,46 @@ exports[`Tooltips in general  – NO tooltips if route doesn't match configurati
         Python tutorial
       </h1>
       <p>
-        Üben macht den Meister.
+        <span
+          class=""
+        >
+          Üben macht den Meister.
+        </span>
       </p>
       <p>
-        Wir üben das. Die Abkürzung AB ist im Glossar erklärt. Wir verwenden AB ab Donnerstag.
+        <span
+          class=""
+        >
+          Wir üben das. Die Abkürzung AB ist im Glossar erklärt. Wir verwenden AB ab Donnerstag.
+        </span>
       </p>
       <p>
-        Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 µg NO2/m3&lt;/strong&gt;
+        <span
+          class=""
+        >
+          Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 µg NO2/m3&lt;/strong&gt;
+        </span>
       </p>
       <p>
-        In automn, Aბㄱ is something you should care about.
+        <span
+          class=""
+        >
+          In automn, Aბㄱ is something you should care about.
+        </span>
       </p>
       <p>
-        Het laatste 8-uurgemiddelde van een dag wordt berekend van 16:00 uur tot 24:00 uur.
+        <span
+          class=""
+        >
+          Het laatste 8-uurgemiddelde van een dag wordt berekend van 16:00 uur tot 24:00 uur.
+        </span>
       </p>
       <p>
-        Morgen üben wir weiter.
+        <span
+          class=""
+        >
+          Morgen üben wir weiter.
+        </span>
       </p>
     </div>
     <div

--- a/packages/volto-slate-glossary/src/components/__snapshots__/Tooltips.test.jsx.snap
+++ b/packages/volto-slate-glossary/src/components/__snapshots__/Tooltips.test.jsx.snap
@@ -26,88 +26,112 @@ exports[`Tooltips are generated for all occurrences 1`] = `
           class=""
         >
           <span
-            class="glossarytooltip"
+            class=""
           >
-            Üben
+            <span
+              class="glossarytooltip"
+            >
+              Üben
+            </span>
+             macht den Meister.
           </span>
-           macht den Meister.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Wir 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            üben
+            Wir 
+            <span
+              class="glossarytooltip"
+            >
+              üben
+            </span>
+             das. Die Abkürzung 
+            <span
+              class="glossarytooltip"
+            >
+              AB
+            </span>
+             ist im Glossar erklärt. Wir verwenden 
+            <span
+              class="glossarytooltip"
+            >
+              AB
+            </span>
+             ab Donnerstag.
           </span>
-           das. Die Abkürzung 
-          <span
-            class="glossarytooltip"
-          >
-            AB
-          </span>
-           ist im Glossar erklärt. Wir verwenden 
-          <span
-            class="glossarytooltip"
-          >
-            AB
-          </span>
-           ab Donnerstag.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            µg
+            Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 
+            <span
+              class="glossarytooltip"
+            >
+              µg
+            </span>
+             NO2/m3&lt;/strong&gt;
           </span>
-           NO2/m3&lt;/strong&gt;
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          In automn, 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            Aბㄱ
+            In automn, 
+            <span
+              class="glossarytooltip"
+            >
+              Aბㄱ
+            </span>
+             is something you should care about.
           </span>
-           is something you should care about.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Het laatste 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            8-uurgemiddelde
+            Het laatste 
+            <span
+              class="glossarytooltip"
+            >
+              8-uurgemiddelde
+            </span>
+             van een dag wordt berekend van 16:00 uur tot 24:00 uur.
           </span>
-           van een dag wordt berekend van 16:00 uur tot 24:00 uur.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Morgen 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            üben
+            Morgen 
+            <span
+              class="glossarytooltip"
+            >
+              üben
+            </span>
+             wir weiter.
           </span>
-           wir weiter.
         </span>
       </p>
     </div>
@@ -153,84 +177,108 @@ exports[`Tooltips are generated only case sensitive 1`] = `
         <span
           class=""
         >
-          Üben macht den Meister.
+          <span
+            class=""
+          >
+            Üben macht den Meister.
+          </span>
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Wir 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            üben
+            Wir 
+            <span
+              class="glossarytooltip"
+            >
+              üben
+            </span>
+             das. Die Abkürzung 
+            <span
+              class="glossarytooltip"
+            >
+              AB
+            </span>
+             ist im Glossar erklärt. Wir verwenden 
+            <span
+              class="glossarytooltip"
+            >
+              AB
+            </span>
+             ab Donnerstag.
           </span>
-           das. Die Abkürzung 
-          <span
-            class="glossarytooltip"
-          >
-            AB
-          </span>
-           ist im Glossar erklärt. Wir verwenden 
-          <span
-            class="glossarytooltip"
-          >
-            AB
-          </span>
-           ab Donnerstag.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            µg
+            Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 
+            <span
+              class="glossarytooltip"
+            >
+              µg
+            </span>
+             NO2/m3&lt;/strong&gt;
           </span>
-           NO2/m3&lt;/strong&gt;
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          In automn, 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            Aბㄱ
+            In automn, 
+            <span
+              class="glossarytooltip"
+            >
+              Aბㄱ
+            </span>
+             is something you should care about.
           </span>
-           is something you should care about.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Het laatste 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            8-uurgemiddelde
+            Het laatste 
+            <span
+              class="glossarytooltip"
+            >
+              8-uurgemiddelde
+            </span>
+             van een dag wordt berekend van 16:00 uur tot 24:00 uur.
           </span>
-           van een dag wordt berekend van 16:00 uur tot 24:00 uur.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Morgen 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            üben
+            Morgen 
+            <span
+              class="glossarytooltip"
+            >
+              üben
+            </span>
+             wir weiter.
           </span>
-           wir weiter.
         </span>
       </p>
     </div>
@@ -277,70 +325,94 @@ exports[`Tooltips are generated only for first occurrences per page 1`] = `
           class=""
         >
           <span
-            class="glossarytooltip"
+            class=""
           >
-            Üben
+            <span
+              class="glossarytooltip"
+            >
+              Üben
+            </span>
+             macht den Meister.
           </span>
-           macht den Meister.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Wir üben das. Die Abkürzung 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            AB
+            Wir üben das. Die Abkürzung 
+            <span
+              class="glossarytooltip"
+            >
+              AB
+            </span>
+             ist im Glossar erklärt. Wir verwenden AB ab Donnerstag.
           </span>
-           ist im Glossar erklärt. Wir verwenden AB ab Donnerstag.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            µg
+            Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 
+            <span
+              class="glossarytooltip"
+            >
+              µg
+            </span>
+             NO2/m3&lt;/strong&gt;
           </span>
-           NO2/m3&lt;/strong&gt;
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          In automn, 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            Aბㄱ
+            In automn, 
+            <span
+              class="glossarytooltip"
+            >
+              Aბㄱ
+            </span>
+             is something you should care about.
           </span>
-           is something you should care about.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Het laatste 
           <span
-            class="glossarytooltip"
+            class=""
           >
-            8-uurgemiddelde
+            Het laatste 
+            <span
+              class="glossarytooltip"
+            >
+              8-uurgemiddelde
+            </span>
+             van een dag wordt berekend van 16:00 uur tot 24:00 uur.
           </span>
-           van een dag wordt berekend van 16:00 uur tot 24:00 uur.
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Morgen üben wir weiter.
+          <span
+            class=""
+          >
+            Morgen üben wir weiter.
+          </span>
         </span>
       </p>
     </div>
@@ -386,42 +458,66 @@ exports[`Tooltips in general  – NO tooltips if route doesn't match configurati
         <span
           class=""
         >
-          Üben macht den Meister.
+          <span
+            class=""
+          >
+            Üben macht den Meister.
+          </span>
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Wir üben das. Die Abkürzung AB ist im Glossar erklärt. Wir verwenden AB ab Donnerstag.
+          <span
+            class=""
+          >
+            Wir üben das. Die Abkürzung AB ist im Glossar erklärt. Wir verwenden AB ab Donnerstag.
+          </span>
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 µg NO2/m3&lt;/strong&gt;
+          <span
+            class=""
+          >
+            Bij volledige elektrificatie: &lt;strong&gt;Canyon: Tot -57% of tot -17 µg NO2/m3&lt;/strong&gt;
+          </span>
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          In automn, Aბㄱ is something you should care about.
+          <span
+            class=""
+          >
+            In automn, Aბㄱ is something you should care about.
+          </span>
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Het laatste 8-uurgemiddelde van een dag wordt berekend van 16:00 uur tot 24:00 uur.
+          <span
+            class=""
+          >
+            Het laatste 8-uurgemiddelde van een dag wordt berekend van 16:00 uur tot 24:00 uur.
+          </span>
         </span>
       </p>
       <p>
         <span
           class=""
         >
-          Morgen üben wir weiter.
+          <span
+            class=""
+          >
+            Morgen üben wir weiter.
+          </span>
         </span>
       </p>
     </div>

--- a/packages/volto-slate-glossary/src/index.js
+++ b/packages/volto-slate-glossary/src/index.js
@@ -15,7 +15,7 @@ const applyConfig = (config) => {
   };
 
   config.settings.slate.leafs = {
-    text: ({ children }) => TextWithGlossaryTooltips({ text: children }),
+    text: ({ children }) => <TextWithGlossaryTooltips text={children} />,
   };
 
   config.settings.appExtras = [

--- a/packages/volto-slate-glossary/src/utils.js
+++ b/packages/volto-slate-glossary/src/utils.js
@@ -28,42 +28,39 @@ export const TextWithGlossaryTooltips = ({ text }) => {
   const currentuser = useSelector((state) => state.users?.user);
 
   /**
-   * Skip enhancing with tooltip markup for some conditions
+   * Skip enhancing with tooltip markup for some conditions.
+   * Always wrap in <span> so server and client render identical DOM structure.
    */
 
   // No tooltips if pathname is not configured to have tooltips
   if (!tooltippedTexts?.pathname || tooltippedTexts?.pathname !== pathname) {
-    return text;
+    return <span className="">{text}</span>;
   }
 
   // No tooltips if user opted out
   const showGlossarytooltipsUser = currentuser?.glossarytooltips ?? true;
   if (!showGlossarytooltipsUser) {
-    return text;
+    return <span className="">{text}</span>;
   }
 
   // No tooltips on home page, in edit mode, and add mode
   if (pathname === undefined) {
-    return text;
+    return <span className="">{text}</span>;
   }
   const isEditMode = pathname.slice(-5) === '/edit';
   if (isEditMode || pathname === '/' || !__CLIENT__) {
-    return text;
+    return <span className="">{text}</span>;
   }
 
   let uid;
   try {
     uid = uuidv5(text, MY_NAMESPACE);
   } catch (error) {
-    // "RangeError: offset is out of bounds"
-    // generateUUID
-    // node_modules/.pnpm/uuid@8.3.2/node_modules/uuid/dist/esm-browser/v35.js:36
-    // console.error(error);
-    return text;
+    return <span className="">{text}</span>;
   }
   // No match in store if this location is not configured for tooltips. Return text unchanged.
   const newText = Object.keys(tooltippedTexts?.texts).includes(uid)
     ? tooltippedTexts.texts[uid]
     : text;
-  return newText;
+  return <span className="">{newText}</span>;
 };

--- a/packages/volto-slate-glossary/src/utils.test.jsx
+++ b/packages/volto-slate-glossary/src/utils.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
+import { Provider } from 'react-intl-redux';
+import { TextWithGlossaryTooltips } from './utils';
+
+const mockStore = configureStore();
+
+const baseStore = {
+  router: {
+    location: { pathname: '/test' },
+  },
+  intl: {
+    locale: 'en',
+    messages: {},
+  },
+  users: {
+    user: {},
+  },
+};
+
+const Wrapper = ({ store, children }) => (
+  <Provider store={store}>{children}</Provider>
+);
+
+describe('TextWithGlossaryTooltips', () => {
+  it('renders text unchanged when no tooltips are available', () => {
+    const store = mockStore(baseStore);
+    const { container } = render(
+      <Wrapper store={store}>
+        <TextWithGlossaryTooltips text="Hello World" />
+      </Wrapper>,
+    );
+    expect(container).toHaveTextContent('Hello World');
+  });
+
+  it('does not throw hooks error when number of instances changes between renders', () => {
+    const store = mockStore(baseStore);
+
+    // Parent component that renders a variable number of TextWithGlossaryTooltips
+    const DynamicList = ({ items }) => (
+      <div>
+        {items.map((item, i) => (
+          <p key={i}>
+            <TextWithGlossaryTooltips text={item} />
+          </p>
+        ))}
+      </div>
+    );
+
+    // First render: 2 items
+    const { rerender } = render(
+      <Wrapper store={store}>
+        <DynamicList items={['First', 'Second']} />
+      </Wrapper>,
+    );
+
+    // Re-render with 4 items — this would crash with the function-call pattern
+    expect(() => {
+      rerender(
+        <Wrapper store={store}>
+          <DynamicList items={['First', 'Second', 'Third', 'Fourth']} />
+        </Wrapper>,
+      );
+    }).not.toThrow();
+
+    // Re-render back to 1 item
+    expect(() => {
+      rerender(
+        <Wrapper store={store}>
+          <DynamicList items={['Only one']} />
+        </Wrapper>,
+      );
+    }).not.toThrow();
+  });
+});

--- a/packages/volto-slate-glossary/src/utils.test.jsx
+++ b/packages/volto-slate-glossary/src/utils.test.jsx
@@ -34,6 +34,36 @@ describe('TextWithGlossaryTooltips', () => {
     expect(container).toHaveTextContent('Hello World');
   });
 
+  it('always wraps output in a span element for consistent SSR/client rendering', () => {
+    // No tooltips configured — should still return a <span>
+    const store = mockStore(baseStore);
+    const { container } = render(
+      <Wrapper store={store}>
+        <TextWithGlossaryTooltips text="Some text" />
+      </Wrapper>,
+    );
+    const span = container.querySelector('span');
+    expect(span).not.toBeNull();
+    expect(span).toHaveTextContent('Some text');
+  });
+
+  it('wraps output in span when pathname does not match', () => {
+    const store = mockStore({
+      ...baseStore,
+      glossarytooltipterms: {
+        result: { items: [], items_total: 0 },
+      },
+    });
+    const { container } = render(
+      <Wrapper store={store}>
+        <TextWithGlossaryTooltips text="Mismatched path" />
+      </Wrapper>,
+    );
+    const span = container.querySelector('span');
+    expect(span).not.toBeNull();
+    expect(span).toHaveTextContent('Mismatched path');
+  });
+
   it('does not throw hooks error when number of instances changes between renders', () => {
     const store = mockStore(baseStore);
 


### PR DESCRIPTION
## Summary

Calling `TextWithGlossaryTooltips` as a function instead of rendering it as a JSX component causes its hooks (`useSelector`, `useAtomValue`) to be attributed to the parent component. When the number of text leafs or block instances changes between renders (e.g. adding a TeaserBox), React throws:

> Error: Rendered more hooks than during the previous render.

This PR changes all call sites from:
```js
TextWithGlossaryTooltips({ text: children })
```
to:
```jsx
<TextWithGlossaryTooltips text={children} />
```

## Changes

- **Slate leaf config** (`index.js`): render as JSX component
- **Policy components**: fix TeaserView, TitleBlockView, DescriptionBlockView, AccordionBlockView
- **Tooltips.jsx**: refactor `calculateTexts` to extract helpers, add support for InfoBox content, table cells, slider slides, and CardSection columns
- **Test setup**: fix `jest-addon.config.js` roots/testMatch so addon tests are actually discovered
- **Regression test**: new `utils.test.jsx` verifying hooks stability with varying instance count